### PR TITLE
Hotfix to facilitate Heroku app deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Build folder for deployment
+build

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
     "web-vitals": "^2.1.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "dev": "react-scripts start",
+    "start": "serve -s build",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "heroku-postbuild": "npm run build"
   },
   "eslintConfig": {
     "extends": [

--- a/src/components/ListingCard/listingCard.js
+++ b/src/components/ListingCard/listingCard.js
@@ -9,7 +9,7 @@ const ListingCard = props => {
             <div 
             className={listingCardStyles["avatar"]} 
             style={{
-                backgroundImage: (avatarLink || "url(/images/img_avatardefault.jpg)")
+                backgroundImage: (avatarLink || "url(/images/img_avatarDefault.jpg)")
             }}
             ></div>
 


### PR DESCRIPTION
The following small tweaks have been made:
- added "build" folder to .gitignore, as the folder is redundant (can be generated using `npm run build`)
- modified "scripts" under package.json to facilitate for app deployment on Heroku
- fixed small typo in default avatar link under ListingCard

