### PR TITLE
Listing Modal Display

### DIFF
--- a/src/components/ListingCard/listingCard.js
+++ b/src/components/ListingCard/listingCard.js
@@ -4,7 +4,16 @@ import Card from "react-bootstrap/Card";
 import Carousel from "react-bootstrap/Carousel";
 import listingCardStyles from "./listingCard.module.css";
 
-const ListingCard = ({ avatarUrl, image_urls, level, rates, fields }) => {
+const ListingCard = ({
+  avatarUrl,
+  username,
+  image_urls,
+  level,
+  rates,
+  fields,
+  setModalState,
+  creator_id,
+}) => {
   const levelParams = {
     primary: "Primary",
     secondary: "Secondary",
@@ -14,11 +23,25 @@ const ListingCard = ({ avatarUrl, image_urls, level, rates, fields }) => {
     others: "Others",
   };
 
+  const showModal = (e) => {
+    if (e.target.className.includes("carousel-control")) return;
+    setModalState({
+      show: true,
+      username,
+      avatarUrl,
+      image_urls,
+      fields,
+      creator_id,
+    });
+  };
   return (
-    <Card className={listingCardStyles.card + " mx-sm-3 my-3 py-4 rounded-5"}>
+    <Card
+      className={listingCardStyles.card + " mx-sm-3 my-3 py-4 rounded-5"}
+      onClick={showModal}
+    >
       {/* Carousel to display avatar image + listing images */}
       {/* Note: Consider adding a modal image on click to show full image */}
-      <Card.Body className="d-flex justify-center">
+      <Card.Body className="d-flex justify-center avatar-section">
         <Carousel
           variant="dark"
           indicators={false}

--- a/src/components/ListingCard/listingCard.module.css
+++ b/src/components/ListingCard/listingCard.module.css
@@ -1,6 +1,7 @@
 .card {
     box-shadow: 0px 4px 4px #00000040;
     width: 205px;
+    cursor: pointer;
 }
 
 .avatar {

--- a/src/components/ListingModal/listingModal.js
+++ b/src/components/ListingModal/listingModal.js
@@ -9,7 +9,8 @@ import FieldTag from "components/FieldTag/fieldTag";
 
 const ListingModal = (props) => {
   const { onHide, data } = props;
-  const { show, username, avatarUrl, image_urls, fields, creator_id } = data;
+  const { show, username, avatarUrl, image_urls, fields /*,creator_id*/ } =
+    data;
   const tagNames = {
     subject: "Subjects",
     commitment: "Commitment Period",

--- a/src/components/ListingModal/listingModal.js
+++ b/src/components/ListingModal/listingModal.js
@@ -1,0 +1,82 @@
+import React from "react";
+import Modal from "react-bootstrap/Modal";
+import listingModalStyles from "./listingModal.module.css";
+import Button from "react-bootstrap/Button";
+import Carousel from "react-bootstrap/Carousel";
+import Row from "react-bootstrap/Row";
+import Col from "react-bootstrap/Col";
+import FieldTag from "components/FieldTag/fieldTag";
+
+const ListingModal = (props) => {
+  const { onHide, data } = props;
+  const { show, username, avatarUrl, image_urls, fields, creator_id } = data;
+  const tagNames = {
+    subject: "Subjects",
+    commitment: "Commitment Period",
+    qualifications: "Qualifications",
+    timing: "Preferred Timings",
+    others: "Others",
+  };
+
+  const tags = fields.reduce((acc, obj) => {
+    const key = obj.category;
+    acc[key] = [...(acc[key] || []), obj.value];
+    return acc;
+  }, {});
+
+  return (
+    <Modal show={show} onHide={onHide}>
+      <Modal.Header closeButton>
+        <img
+          src={avatarUrl || "/images/img_avatarDefault.jpg"}
+          alt="Avatar"
+          className={listingModalStyles.avatar}
+        />
+        <a href="/" className="nunito-sans">
+          {username}
+        </a>
+        {/* Add rating here! (stars) */}
+      </Modal.Header>
+      <Modal.Body>
+        <Row className={`${listingModalStyles["image-section"]} pb-4`}>
+          {!image_urls || image_urls.length < 1 ? (
+            <h1 className="text-center ">No listing images!</h1>
+          ) : (
+            <Carousel
+              variant="dark"
+              indicators={false}
+              controls={image_urls.length > 1}
+              interval={null}
+            >
+              {image_urls.map((imgUrl) => (
+                <Carousel.Item
+                  className={listingModalStyles["carousel-item"]}
+                  key={imgUrl}
+                >
+                  <img src={imgUrl} alt="Listing Details" />
+                </Carousel.Item>
+              ))}
+            </Carousel>
+          )}
+        </Row>
+        {Object.keys(tags).map((tag) => (
+          <Row className={listingModalStyles["tag-row"]}>
+            <Col
+              className={listingModalStyles["tag-header"]}
+              xs={5}
+            >{`${tagNames[tag]}: `}</Col>
+            <Col xs={7}>
+              <FieldTag category={tag} value={tags[tag]} key={tag} />
+            </Col>
+          </Row>
+        ))}
+      </Modal.Body>
+      <Modal.Footer className="px-4 d-flex justify-content-evenly">
+        <Button variant="outline-secondary">View Profile</Button>
+        <Button className="px-5">Chat</Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default ListingModal;

--- a/src/components/ListingModal/listingModal.module.css
+++ b/src/components/ListingModal/listingModal.module.css
@@ -25,6 +25,6 @@
 
 .tag-header {
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
     text-align: end;
 }

--- a/src/components/ListingModal/listingModal.module.css
+++ b/src/components/ListingModal/listingModal.module.css
@@ -1,0 +1,30 @@
+.avatar {
+    width: 30px;
+    height: 30px;
+    border-radius: 15px;
+    border-width: 1px;
+    margin-right: 10px;
+}
+
+.image-section {
+    min-height: 200px;
+    display:flex;
+    align-items: center;
+}
+
+.carousel-item img {
+    margin: auto;
+    width: 80%;
+}
+
+.tag-row {
+    padding: 10px 0px;
+    display: flex;
+    align-items: center;
+}
+
+.tag-header {
+    display: flex;
+    justify-content: end;
+    text-align: end;
+}

--- a/src/pages/ListingsPage/listingsPage.js
+++ b/src/pages/ListingsPage/listingsPage.js
@@ -9,7 +9,7 @@ import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import Spinner from "react-bootstrap/Spinner";
-
+import ListingModal from "components/ListingModal/listingModal";
 import listingsPageStyles from "./listingsPage.module.css";
 
 const ListingsPage = () => {
@@ -17,16 +17,30 @@ const ListingsPage = () => {
   const [tutorTutee, setTutorTutee] = useState("tutor");
   const [listingData, setListingData] = useState([]);
   const [query, setQuery] = useState("");
+  const unusedModalState = {
+    show: false,
+    username: "",
+    avatarUrl: "",
+    image_urls: [],
+    fields: [],
+    creator_id: "",
+  };
+  const [modalState, setModalState] = useState(unusedModalState);
 
   return (
     <div
       style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}
     >
       <NavBar />
+      <ListingModal
+        data={modalState}
+        onHide={() => setModalState(unusedModalState)}
+      />
       <ListingPageBody
         tutorTuteeState={[tutorTutee, setTutorTutee]}
         listingDataState={[listingData, setListingData]}
         queryState={[query, setQuery]}
+        setModalState={setModalState}
       />
       <FooterBar />
     </div>
@@ -35,7 +49,12 @@ const ListingsPage = () => {
 
 export default ListingsPage;
 
-const ListingPageBody = ({ tutorTuteeState, listingDataState, queryState }) => {
+const ListingPageBody = ({
+  tutorTuteeState,
+  listingDataState,
+  queryState,
+  setModalState,
+}) => {
   // Stores the text of the tutor/tutee toggle
   const [tutorTutee, setTutorTutee] = tutorTuteeState;
   // Stores the text entered into the search bar
@@ -105,6 +124,7 @@ const ListingPageBody = ({ tutorTuteeState, listingDataState, queryState }) => {
         tutorTutee={tutorTutee}
         listingDataState={listingDataState}
         query={query}
+        setModalState={setModalState}
       />
     </Container>
   );
@@ -126,7 +146,7 @@ const TutorTuteeToggle = ({ tutorTutee, setTutorTutee }) => {
   );
 };
 
-const Listings = ({ tutorTutee, listingDataState, query }) => {
+const Listings = ({ tutorTutee, listingDataState, query, setModalState }) => {
   // Set to true when data is being fetched from Supabase
   const [loading, setLoading] = useState(false);
 
@@ -184,12 +204,12 @@ const Listings = ({ tutorTutee, listingDataState, query }) => {
               listing_id,
             }) => {
               let {
-                data: { avatar_url: avatarTitle },
+                data: { avatar_url: avatarTitle, username },
                 error: avatarError,
                 status: avatarStatus,
               } = await supabase
                 .from("profiles")
-                .select("avatar_url")
+                .select("username, avatar_url")
                 .eq("id", creator_id)
                 .single();
               if (avatarError && avatarStatus !== 406) throw avatarError;
@@ -202,11 +222,13 @@ const Listings = ({ tutorTutee, listingDataState, query }) => {
 
               return {
                 avatarUrl,
+                username,
                 level,
                 rates,
                 fields,
                 image_urls,
                 listing_id,
+                creator_id,
               };
             }
           )
@@ -237,16 +259,28 @@ const Listings = ({ tutorTutee, listingDataState, query }) => {
       ) : (
         <React.Fragment>
           {listingData.map(
-            ({ avatarUrl, level, rates, fields, image_urls, listing_id }) => {
+            ({
+              avatarUrl,
+              username,
+              level,
+              rates,
+              fields,
+              image_urls,
+              listing_id,
+              creator_id,
+            }) => {
               return (
                 (
                   <ListingCard
                     avatarUrl={avatarUrl}
+                    username={username}
                     key={listing_id}
                     level={level}
                     rates={rates}
                     image_urls={image_urls}
                     fields={fields}
+                    setModalState={setModalState}
+                    creator_id={creator_id}
                   />
                 ) || <h1>Nothing here!</h1>
               );

--- a/src/styles/style-guide.css
+++ b/src/styles/style-guide.css
@@ -252,6 +252,12 @@
   font-weight: 400;
   font-style: normal;
 }
+.nunito {
+  font-family: "Nunito";
+}
+.nunito-sans {
+  font-family: "Nunito Sans";
+}
 .nunito-semi-bold-black-24px {
   color: var(--black);
   font-family: var(--font-family-nunito);
@@ -272,6 +278,9 @@
   font-size: var(--font-size-xl);
   font-weight: 700;
   font-style: normal;
+}
+.inter {
+  font-family: "Inter";
 }
 .inter-medium-black-20px {
   color: var(--black-2);


### PR DESCRIPTION
Added a listing modal that is displayed whenever a listing card is clicked!
Essentially shows clearer details of the clicked listing + allows users to contact listing creator.

Changelog:
- Listing Modal Display (click on a listing card on the Listings Page to find out more)
  - Shows listing creator profile pic and username on modal header
    - Creator username to link to profile page. To be implemented once profile page is done.
    - Ratings (stars out of 5) to be added once ready as well
  - Shows enlarged version of listing images
  - Clearer display of listing tags
  - View Profile and Chat buttons on the footer
    - To be implemented once Chat and Profile Page are done!