### PR TITLE
Show Toast across changing pages + Bug #106 Fix

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,51 @@
+import { useState } from "react";
 import Routes from "./Routes";
 import Toast from "react-bootstrap/Toast";
 import ToastContainer from "react-bootstrap/ToastContainer";
 
 function App() {
+  // States for Toast
+  const defaultToastOptions = {
+    show: false,
+    closeButton: false,
+    position: "bottom-end",
+    containerClasses: "p-4",
+    variant: "light",
+    autohide: true,
+    delay: 2000,
+    headerContent: "",
+    bodyContent: "",
+  };
+  const [toastOptions, setToastOptions] = useState(defaultToastOptions);
+  const {
+    show,
+    position,
+    containerClasses,
+    variant,
+    autohide,
+    delay,
+    headerContent,
+    bodyContent,
+    closeButton,
+  } = toastOptions;
+
   return (
     <>
-      <Routes />
-      <ToastContainer position="bottom-end" className="position-fixed">
-        <Toast>
-          <Toast.Header>hi</Toast.Header>
-          <Toast.Body>Hi</Toast.Body>
+      <Routes setToastOptions={setToastOptions} />
+      <ToastContainer
+        position={position}
+        className={"position-fixed " + containerClasses}
+      >
+        <Toast
+          bg={variant}
+          autohide={autohide}
+          delay={delay}
+          show={show}
+          closeButton={closeButton}
+          onClose={() => setToastOptions((old) => ({ ...old, show: false }))}
+        >
+          <Toast.Header>{headerContent}</Toast.Header>
+          <Toast.Body>{bodyContent}</Toast.Body>
         </Toast>
       </ToastContainer>
     </>

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,19 @@
 import Routes from "./Routes";
+import Toast from "react-bootstrap/Toast";
+import ToastContainer from "react-bootstrap/ToastContainer";
 
 function App() {
-  return <Routes />;
+  return (
+    <>
+      <Routes />
+      <ToastContainer position="bottom-end" className="position-fixed">
+        <Toast>
+          <Toast.Header>hi</Toast.Header>
+          <Toast.Body>Hi</Toast.Body>
+        </Toast>
+      </ToastContainer>
+    </>
+  );
 }
 
 export default App;

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -16,13 +16,16 @@ import NotFound from "pages/NotFound";
 import ChatPage from "pages/ChatPage/chatPage";
 import ReviewPage from "pages/ReviewPage/reviewPage";
 
-const ProjectRoutes = () => {
+const ProjectRoutes = ({ setToastOptions }) => {
   return (
     <Router>
       <Routes>
         <Route path="/" element={<LandingPage />} />
         <Route path="*" element={<NotFound />} />
-        <Route path="/loginpage" element={<LoginPage />} />
+        <Route
+          path="/loginpage"
+          element={<LoginPage setToastOptions={setToastOptions} />}
+        />
         <Route path="/registerpage" element={<RegisterPage />} />
         <Route path="/aboutuspage" element={<AboutusPage />} />
         <Route path="/listingspage" element={<ListingsPage />} />

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -17,6 +17,20 @@ import ChatPage from "pages/ChatPage/chatPage";
 import ReviewPage from "pages/ReviewPage/reviewPage";
 
 const ProjectRoutes = ({ setToastOptions }) => {
+  // Simplify toast showing
+  const showSimpleToast = (title, message, timeout) =>
+    setToastOptions({
+      show: true,
+      closeButton: false,
+      position: "bottom-end",
+      containerClasses: "p-4",
+      variant: "light",
+      autohide: true,
+      delay: timeout,
+      headerContent: title,
+      bodyContent: message,
+    });
+
   return (
     <Router>
       <Routes>
@@ -24,7 +38,7 @@ const ProjectRoutes = ({ setToastOptions }) => {
         <Route path="*" element={<NotFound />} />
         <Route
           path="/loginpage"
-          element={<LoginPage setToastOptions={setToastOptions} />}
+          element={<LoginPage showSimpleToast={showSimpleToast} />}
         />
         <Route path="/registerpage" element={<RegisterPage />} />
         <Route path="/aboutuspage" element={<AboutusPage />} />

--- a/src/pages/LoginPage/login.js
+++ b/src/pages/LoginPage/login.js
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { supabaseClient } from "../../config/supabase-client";
 import loginPageStyles from "./login.module.css";
 
-const LoginPage = ({ setToastOptions }) => {
+const LoginPage = ({ showSimpleToast }) => {
   const navigate = useNavigate();
   const home = () => navigate("/");
   const registerPage = () => navigate("/registerpage");
@@ -46,17 +46,7 @@ const LoginPage = ({ setToastOptions }) => {
         });
         if (error) throw error;
 
-        setToastOptions({
-          show: true,
-          closeButton: false,
-          position: "bottom-end",
-          containerClasses: "p-4",
-          variant: "light",
-          autohide: true,
-          delay: 2000,
-          headerContent: "Logged In",
-          bodyContent: "You have successfully logged in.",
-        });
+        showSimpleToast("Logged In", "You have successfully logged in!", 2000);
         navigate("/listingspage");
       } catch (error) {
         alert("You have entered an invalid email or password");

--- a/src/pages/LoginPage/login.js
+++ b/src/pages/LoginPage/login.js
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { supabaseClient } from "../../config/supabase-client";
 import loginPageStyles from "./login.module.css";
 
-const LoginPage = () => {
+const LoginPage = ({ setToastOptions }) => {
   const navigate = useNavigate();
   const home = () => navigate("/");
   const registerPage = () => navigate("/registerpage");
@@ -46,6 +46,17 @@ const LoginPage = () => {
         });
         if (error) throw error;
 
+        setToastOptions({
+          show: true,
+          closeButton: false,
+          position: "bottom-end",
+          containerClasses: "p-4",
+          variant: "light",
+          autohide: true,
+          delay: 2000,
+          headerContent: "Logged In",
+          bodyContent: "You have successfully logged in.",
+        });
         navigate("/listingspage");
       } catch (error) {
         alert("You have entered an invalid email or password");


### PR DESCRIPTION
Implemented most of the Toast logic under App.js.
Simplified process of showing toast by creating a `showSimpleToast` method under Routes.js.
[EDIT] Also added bug fix for issue #106.

Added a successful login Toast after logging in under LoginPage. 
See login.js for a demo of how it works

# How to get started?
1. Under Routes.js, pass in either one of these two methods to the page you wish to generate a toast from.
    1. `setToastOptions`
    2. `showSimpleToast`
2. In the page with one of the methods passed in, use the method to generate a toast.

# What's the difference between the two methods?
`showSimpleToast` actually calls `setToastOptions` under the hood, with default values for most of the parameters.
Here is a detailed description of them:
- `setToastOptions`: takes in an object with the following attributes
  - `show` (boolean): Set to true to show toast
  - `closeButton `(boolean): Set to true to show a close button on the toast header
  - `position `(string): Where to display the toast
  - `containerClasses `(string): Any additional classes to add to the ToastContainer component
  - `variant `(string): The colour variant of the toast
  - `autohide `(boolean): Set to true to allow it to dismiss itself after `delay` milliseconds
  - `delay `(number): Number of milliseconds to wait before dismissing the toast, given `autohide` is true
  - `headerContant `(any): The content that will be displayed inside the Toast header
  - `bodyContent `(any): The content that will be displayed inside the Toast header
- `showSimpleToast`: takes in 3 arguments and displays a simple Toast that vanishes after a set period of time
  - `title` (string): The title of the toast to be shown
  - `message` (string): The message to be shown on the toast
  - `timeout` (number): The number of milliseconds to wait before closing the toast