### PR TITLE
[Listings] Implemented Edit Listings + Persistence of Tutor/Tutee filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@testing-library/user-event": "^12.8.3",
         "bootstrap": "^5.2.0-beta1",
         "bootstrap-icons": "^1.8.3",
+        "lodash": "^4.17.21",
         "moment": "^2.29.3",
         "msw": "^0.43.1",
         "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@testing-library/user-event": "^12.8.3",
     "bootstrap": "^5.2.0-beta1",
     "bootstrap-icons": "^1.8.3",
+    "lodash": "^4.17.21",
     "moment": "^2.29.3",
     "msw": "^0.43.1",
     "react": "^17.0.2",

--- a/src/App.js
+++ b/src/App.js
@@ -37,19 +37,29 @@ function App() {
   const { authData, setAuthData, setAuthLoading } = useContext(AuthContext);
 
   const parseProfile = (profileData) => {
-    const { id, username, avatar_url, permissions, blocked, gender, bio } = profileData;
+    const {
+      id,
+      username,
+      avatar_url,
+      permissions,
+      preferences,
+      blocked,
+      gender,
+      bio,
+    } = profileData;
     return {
       logged_in: true,
       username,
       gender,
       bio,
       permissions,
+      preferences,
       avatar_url: avatar_url
         ? supabaseClient.storage.from("avatars").getPublicUrl(avatar_url)
             .publicURL
         : "/images/img_avatarDefault.jpg",
-      id, 
-      blocked
+      id,
+      blocked,
     };
   };
   // Initialise authData and setup listeners, only done once at the start.
@@ -85,9 +95,10 @@ function App() {
           permissions: 0,
           username: null,
           avatar_url: null,
+          preferences: {},
           id: null,
           bio: null,
-          gender: null
+          gender: null,
         };
 
       const { user } = session;
@@ -119,7 +130,11 @@ function App() {
 
   return (
     <>
-      <Routes setToastOptions={setToastOptions} option={option} setOption={setOption} />
+      <Routes
+        setToastOptions={setToastOptions}
+        option={option}
+        setOption={setOption}
+      />
       <ToastContainer
         position={position}
         className={"position-fixed " + containerClasses}

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -106,6 +106,7 @@ const AnimatedRoutes = ({
         path="/chatlogs"
         element={<ChatLogsPage setToastOptions={setToastOptions} />}
       />
+      <Route path="/edit-listing" element={<CreateListingPage isEditing />} />
     </Routes>
   ) : (
     <Routes>

--- a/src/components/Avatar/avatar.js
+++ b/src/components/Avatar/avatar.js
@@ -211,7 +211,12 @@ const PersonalAvatar = ({ url, onUpload, loading }) => {
         />
       </div>
 
-      <Modal size="lg" show={modalShow} onHide={() => setModalShow(false)}>
+      <Modal
+        size="lg"
+        show={modalShow}
+        onHide={() => setModalShow(false)}
+        backdrop="static"
+      >
         <Modal.Title>
           <Modal.Header className="nunito-semi-bold-black-24px" closeButton>
             Crop Profile Picture

--- a/src/components/ListingModal/listingModal.js
+++ b/src/components/ListingModal/listingModal.js
@@ -58,7 +58,7 @@ const ListingModal = (props) => {
     }
   };
 
-  const generateDeleteFooter = () => {
+  const generateFooter = () => {
     switch (deleteState) {
       case 1:
         return (
@@ -87,10 +87,17 @@ const ListingModal = (props) => {
       default:
         return (
           <>
-            {/* Edit button hidden due to incomplete development */}
-            {/* <Button variant="primary" className="px-5">
+            <Button
+              variant="outline-secondary"
+              className="px-5"
+              onClick={() =>
+                navigate("/edit-listing", {
+                  state: { listingId: listing_id },
+                })
+              }
+            >
               Edit
-            </Button> */}
+            </Button>
             <Button
               variant="danger"
               className="px-5"
@@ -107,7 +114,7 @@ const ListingModal = (props) => {
     return (
       <Modal.Footer className="px-4 d-flex justify-content-evenly">
         {isOwnListing ? (
-          generateDeleteFooter()
+          generateFooter()
         ) : (
           <>
             <Button

--- a/src/pages/CreateListingPage/createListingPage.js
+++ b/src/pages/CreateListingPage/createListingPage.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
   supabaseClient as supabase,
   supabaseClient,
@@ -18,47 +18,42 @@ import Button from "react-bootstrap/Button";
 import { PlusCircle } from "react-bootstrap-icons";
 import LoadingOverlay from "react-loading-overlay-ts";
 
-const CreateListingPage = () =>
-  // { isEditing, listingId }
-  {
-    // MOCK DATA FOR TESTING
-    const isEditing = true;
-    const listingId = "cebe83e7-5464-435b-a185-b96df85c3d90";
-    // END OF MOCK DATA
-    // Options to be shown under the selection field dropdown box. Edit if required!
-    const fieldParams = {
-      subject: "Subject",
-      qualifications: "Qualifications",
-      timing: "Preferred Times",
-      commitment: "Commitment Period",
-      others: "Others",
-    };
-
-    // Options to be shown under the education level dropdown box. Edit if required!
-    const levelParams = {
-      primary: "Primary",
-      secondary: "Secondary",
-      tertiary: "Tertiary",
-      undergrad: "Undergraduate",
-      grad: "Graduate",
-      others: "Others",
-    };
-
-    return (
-      <div
-        style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}
-      >
-        <NavBar />
-        <CreateListingBody
-          fieldParams={fieldParams}
-          levelParams={levelParams}
-          isEditing={isEditing}
-          listingId={listingId}
-        />
-        <FooterBar />
-      </div>
-    );
+const CreateListingPage = ({ isEditing }) => {
+  const listingId = useLocation().state?.listingId;
+  // Options to be shown under the selection field dropdown box. Edit if required!
+  const fieldParams = {
+    subject: "Subject",
+    qualifications: "Qualifications",
+    timing: "Preferred Times",
+    commitment: "Commitment Period",
+    others: "Others",
   };
+
+  // Options to be shown under the education level dropdown box. Edit if required!
+  const levelParams = {
+    primary: "Primary",
+    secondary: "Secondary",
+    tertiary: "Tertiary",
+    undergrad: "Undergraduate",
+    grad: "Graduate",
+    others: "Others",
+  };
+
+  return (
+    <div
+      style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}
+    >
+      <NavBar />
+      <CreateListingBody
+        fieldParams={fieldParams}
+        levelParams={levelParams}
+        isEditing={isEditing}
+        listingId={listingId}
+      />
+      <FooterBar />
+    </div>
+  );
+};
 
 export default CreateListingPage;
 
@@ -223,7 +218,7 @@ const CreateListingBody = ({
             if (error) throw error;
 
             const { seeking_for, level, rates, image_urls, fields } = data;
-            setTutorTutee(seeking_for);
+            setTutorTutee(seeking_for === "tutor" ? "tutee" : "tutor");
             setLevel(level);
             setRates(rates);
             setImageURLs(

--- a/src/pages/CreateListingPage/createListingPage.js
+++ b/src/pages/CreateListingPage/createListingPage.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import Badge from "react-bootstrap/Badge";
 import { useNavigate } from "react-router-dom";
 import {
   supabaseClient as supabase,
@@ -249,13 +250,28 @@ const CreateListingBody = ({
   return submitting || loading ? (
     <div className={createListingPageStyles["body"]}>
       <h1 className="nunito-medium-black-48px">
-        {submitting ? "Submitting..." : "Loading your previous listing..."}
+        {submitting
+          ? isEditing
+            ? "Updating your listing..."
+            : "Submitting..."
+          : "Loading your previous listing..."}
       </h1>
       <Spinner animation="border" />
     </div>
   ) : (
     // Actual submission form. Shown only if not submitting and user is logged in.
     <form className={createListingPageStyles["body"]} onSubmit={handleSubmit}>
+      {isEditing && (
+        <>
+          <h1 className="text-success mb-0">You are editing a listing</h1>
+          <hr
+            style={{
+              borderTop: "3px solid #bbb",
+              width: "100%",
+            }}
+          />
+        </>
+      )}
       {/* Fixed field 1: Tutor/Tutee toggle. Defaults to Tutor. */}
       <Row
         className={`${createListingPageStyles["choose-tutor-tutee"]} my-3 mx-4`}
@@ -442,12 +458,13 @@ const CreateListingBody = ({
       <Button
         type="submit"
         className="rounded-pill p-3 w-50"
+        variant={isEditing && "success"}
         style={{
           fontSize: "20px",
-          backgroundColor: "var(--primary400---0354a6)",
+          backgroundColor: isEditing ? "" : "var(--primary400---0354a6)",
         }}
       >
-        Let's Go!
+        {isEditing ? "Edit Listing" : "Let's Go!"}
       </Button>
     </form>
   );

--- a/src/pages/CreateListingPage/createListingPage.js
+++ b/src/pages/CreateListingPage/createListingPage.js
@@ -15,7 +15,7 @@ import Button from "react-bootstrap/Button";
 import { PlusCircle } from "react-bootstrap-icons";
 import LoadingOverlay from "react-loading-overlay-ts";
 
-const CreateListingPage = ({ _userLoggedIn }) => {
+const CreateListingPage = ({ isEditing, editData }) => {
   // Options to be shown under the selection field dropdown box. Edit if required!
   const fieldParams = {
     subject: "Subject",
@@ -35,7 +35,30 @@ const CreateListingPage = ({ _userLoggedIn }) => {
     others: "Others",
   };
 
-  // Hook declarations in root element to maintain single source of truth
+  return (
+    <div
+      style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}
+    >
+      <NavBar />
+      <CreateListingBody
+        fieldParams={fieldParams}
+        levelParams={levelParams}
+        isEditing={isEditing}
+        editData={editData}
+      />
+      <FooterBar />
+    </div>
+  );
+};
+
+export default CreateListingPage;
+
+const CreateListingBody = ({
+  fieldParams,
+  levelParams,
+  isEditing,
+  editData,
+}) => {
   const [submitting, setSubmitting] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [sFieldInputs, setSFieldInputs] = useState([]);
@@ -50,7 +73,7 @@ const CreateListingPage = ({ _userLoggedIn }) => {
 
   // Redirect user to login page if not logged in
   useEffect(() => {
-    if (!_userLoggedIn && !supabase.auth.user()) navigate("/loginpage");
+    if (!supabase.auth.user()) navigate("/loginpage");
 
     // We are disabling the following warning as there is
     // no point in including the navigate method into the
@@ -180,62 +203,6 @@ const CreateListingPage = ({ _userLoggedIn }) => {
       navigate("/listingspage");
     }
   };
-
-  // ------------------ End of method declarations ----------------------
-
-  return (
-    <div
-      style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}
-    >
-      <NavBar />
-      <CreateListingBody
-        selectionFields={sFields}
-        sFieldInputStates={[sFieldInputs, setSFieldInputs]}
-        onImgUpload={onImgUpload}
-        onImgDelete={onImgDelete}
-        uploading={uploading}
-        onSFieldAdd={onSFieldAdd}
-        onSFieldDelete={onSFieldDelete}
-        tutorTutee={tutorTutee}
-        setTutorTutee={setTutorTutee}
-        handleSubmit={handleSubmit}
-        fieldParams={fieldParams}
-        submitting={submitting}
-        rates={rates}
-        setRates={setRates}
-        invalidRates={invalidRates}
-        setInvalidRates={setInvalidRates}
-        imageURLs={imageURLs}
-        levelParams={levelParams}
-      />
-      <FooterBar />
-    </div>
-  );
-};
-
-export default CreateListingPage;
-
-const CreateListingBody = (props) => {
-  const {
-    selectionFields,
-    sFieldInputStates,
-    onSFieldAdd,
-    onSFieldDelete,
-    onImgUpload,
-    onImgDelete,
-    uploading,
-    tutorTutee,
-    setTutorTutee,
-    handleSubmit,
-    fieldParams,
-    submitting,
-    rates,
-    setRates,
-    invalidRates,
-    setInvalidRates,
-    imageURLs,
-    levelParams,
-  } = props;
 
   // Check if submission is in progress. Show "Submitting..." if required.
   return submitting ? (
@@ -402,14 +369,14 @@ const CreateListingBody = (props) => {
             <Row
               className={`${createListingPageStyles["selection-fields"]} my-4 p-3`}
             >
-              {/* Creates a SelectionField for each object present in the selectionFields state.
+              {/* Creates a SelectionField for each object present in the sFields state.
         SelectionField implementation can be found below. */}
-              {selectionFields.map((sField) => (
+              {sFields.map((sField) => (
                 <SelectionField
                   key={sField.id}
                   id={sField.id}
                   onSFieldDelete={onSFieldDelete}
-                  sFieldInputStates={sFieldInputStates}
+                  sFieldInputStates={[sFieldInputs, setSFieldInputs]}
                   fieldParams={fieldParams}
                 />
               ))}

--- a/src/pages/CreateListingPage/createListingPage.module.css
+++ b/src/pages/CreateListingPage/createListingPage.module.css
@@ -189,7 +189,7 @@
   display: flex;
   padding: 0px 1.5em 0px 0.6em;
   height: 40px;
-  font-size: calc(100% + 0.3vw);
+  font-size: 100%;
   position: relative;
   overflow: hidden;
 }

--- a/src/pages/ListingsPage/__test__/listingsPage.test.js
+++ b/src/pages/ListingsPage/__test__/listingsPage.test.js
@@ -26,4 +26,12 @@ describe("Tutor/Tutee toggle", () => {
     wrapPage();
     expect(getToggle()).toBeInTheDocument();
   });
+
+  // Planned: displays tutor/tutee based on user preferences (AuthContext)
+
+  // Planned: toggles correctly
+
+  // Planned: toggling causes update in Supabase profiles table, preferences column (mock Supabase)
+
+  // Planned: updating of Supabase profile preferences uses a debounce effect (timing around 0.25s)
 });

--- a/src/pages/ListingsPage/__test__/listingsPage.test.js
+++ b/src/pages/ListingsPage/__test__/listingsPage.test.js
@@ -1,0 +1,29 @@
+import "@testing-library/jest-dom/extend-expect";
+import { render, screen } from "@testing-library/react";
+import { createMemoryHistory } from "history";
+import { Router } from "react-router-dom";
+import AuthContext from "util/AuthContext";
+import ListingsPage from "../listingsPage";
+
+const wrapPage = (authData = { logged_in: false }) => {
+  const history = createMemoryHistory();
+
+  render(
+    <AuthContext.Provider value={{ authData }}>
+      <Router location={history.location} navigator={history}>
+        <ListingsPage />
+      </Router>
+    </AuthContext.Provider>
+  );
+
+  return history;
+};
+
+describe("Tutor/Tutee toggle", () => {
+  const getToggle = () => screen.getByTestId("tutorTuteeToggle");
+
+  it("should be present in the document", () => {
+    wrapPage();
+    expect(getToggle()).toBeInTheDocument();
+  });
+});

--- a/src/pages/ListingsPage/listingsPage.js
+++ b/src/pages/ListingsPage/listingsPage.js
@@ -129,7 +129,6 @@ const ListingPageBody = ({ setModalState, blockedArray }) => {
 const TutorTuteeToggle = ({ tutorTutee, setTutorTutee }) => {
   // Caches tutor/tutee state 500ms after last change
   const updateLookingFor = (newState) => {
-    console.log(newState);
     localStorage.setItem("lookingFor", newState);
   };
   const debouncedUpdate = useRef(
@@ -239,10 +238,10 @@ const Listings = ({ tutorTutee, query, setModalState, blockedArray }) => {
           );
           setListingData(current);
         }
+
+        setLoading(false);
       } catch (error) {
         alert(error.message);
-      } finally {
-        setLoading(false);
       }
     };
     getListings();
@@ -260,9 +259,7 @@ const Listings = ({ tutorTutee, query, setModalState, blockedArray }) => {
     const listingSub = supabase
       .from("listings")
       .on("INSERT", async (payload) => {
-        console.log(payload);
         const newListingData = await parseListing(payload.new);
-        console.log(newListingData);
         if (filterListing(newListingData)) {
           setListingData((oldListingData) => [
             ...oldListingData,

--- a/src/pages/ListingsPage/listingsPage.js
+++ b/src/pages/ListingsPage/listingsPage.js
@@ -15,10 +15,7 @@ import listingsPageStyles from "./listingsPage.module.css";
 
 const ListingsPage = () => {
   const { authData } = useContext(AuthContext);
-  const { blocked: blockedArray } = authData;
-  const [tutorTutee, setTutorTutee] = useState("tutor");
-  const [listingData, setListingData] = useState([]);
-  const [query, setQuery] = useState("");
+  const { blocked: blockedArray, preferences } = authData;
   const unusedModalState = {
     show: false,
     username: "",
@@ -39,11 +36,9 @@ const ListingsPage = () => {
         onHide={() => setModalState(unusedModalState)}
       />
       <ListingPageBody
-        tutorTuteeState={[tutorTutee, setTutorTutee]}
-        listingDataState={[listingData, setListingData]}
-        queryState={[query, setQuery]}
         setModalState={setModalState}
         blockedArray={blockedArray}
+        lookingFor={preferences?.lookingFor || "tutor"}
       />
       <FooterBar />
     </div>
@@ -52,17 +47,11 @@ const ListingsPage = () => {
 
 export default ListingsPage;
 
-const ListingPageBody = ({
-  tutorTuteeState,
-  listingDataState,
-  queryState,
-  setModalState,
-  blockedArray,
-}) => {
+const ListingPageBody = ({ setModalState, blockedArray }) => {
+  const [tutorTutee, setTutorTutee] = useState("tutor");
+  const [query, setQuery] = useState("");
   // Stores the text of the tutor/tutee toggle
-  const [tutorTutee, setTutorTutee] = tutorTuteeState;
   // Stores the text entered into the search bar
-  const [query, setQuery] = queryState;
 
   const searchHandler = () => {
     setQuery(document.getElementById("search-input").value);
@@ -126,7 +115,6 @@ const ListingPageBody = ({
       {/* Listings */}
       <Listings
         tutorTutee={tutorTutee}
-        listingDataState={listingDataState}
         query={query}
         setModalState={setModalState}
         blockedArray={blockedArray}
@@ -151,18 +139,12 @@ const TutorTuteeToggle = ({ tutorTutee, setTutorTutee }) => {
   );
 };
 
-const Listings = ({
-  tutorTutee,
-  listingDataState,
-  query,
-  setModalState,
-  blockedArray,
-}) => {
+const Listings = ({ tutorTutee, query, setModalState, blockedArray }) => {
+  const [listingData, setListingData] = useState([]);
   // Set to true when data is being fetched from Supabase
   const [loading, setLoading] = useState(false);
 
   // Array of objects containing the data of each listing
-  const [listingData, setListingData] = listingDataState;
 
   const parseListing = async ({
     creator_id,


### PR DESCRIPTION
# Edit Listings
- Users should now be able to see an edit button when clicking on their own listings
- Users should be redirected to the '/edit-listing' page after clicking on the edit button
- Users should see input fields pre-filled with their previous entries
- Users should be able to update their listings with the modified entries
- Users should not be able to access the '/edit-listing' page directly (i.e. user entered link manually rather than clicking on edit button)
# Saving of Tutor/Tutee Filter
- Users should be able to toggle the tutor/tutee filter on view listings page
- Tutor/tutee toggle should remain the same even after the page reloads